### PR TITLE
Updated _gettingstarted so use path library

### DIFF
--- a/source/includes/_gettingstarted.md
+++ b/source/includes/_gettingstarted.md
@@ -26,10 +26,14 @@ async function uploadExample() {
 ```
 
 ```javascript--node
+const fs = require('fs');
+const path = require('path');
 const skynet = require('@nebulous/skynet');
 
 (async () => {
-	const skylink = await skynet.uploadFile("./image.jpg");
+	const skylink = await skynet.uploadFile(
+    path.join(__dirname, '.', image.jpg)
+  );
 	console.log(`Upload successful, skylink: ${skylink}`);
 })();
 ```


### PR DESCRIPTION
Suggesting using the path library so users can access files relative to the current directory.
Otherwise the user may need to access the file relative to the root of their project directory.

<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->