### PR TITLE
Update datakey to the correct capitalization

### DIFF
--- a/source/v2/includes/_registry.md
+++ b/source/v2/includes/_registry.md
@@ -64,14 +64,14 @@ import { SkynetClient, keyPairFromSeed } from "skynet-js";
 const client = new SkynetClient();
 const { publicKey, privateKey } = keyPairFromSeed("this seed should be fairly long for security");
 
-const dataKey = "foo";
+const datakey = "foo";
 const data = "bar";
 const revision = 0;
 const entry = { datakey, data, revision };
 
 async function setEntryExample() {
   try {
-    await client.registry.setEntry(privateKey, dataKey, entry);
+    await client.registry.setEntry(privateKey, datakey, entry);
   } catch (error) {
     console.log(error);
   }


### PR DESCRIPTION
This tripped me up when implementing an application using the registry.
`datakey` needs to be in that exact casing as part of entry, but the const definition for the docs has it camelCased.