### PR TITLE
fix  broken uploadDirectory example

### DIFF
--- a/source/includes/_uploading.md
+++ b/source/includes/_uploading.md
@@ -171,7 +171,7 @@ async function uploadDirectoryExample() {
       return { ...accumulator, [path]: file };
     }, {});
 
-    const { skylink } = await client.uploadDirectory(directory, filename);
+    const skylink = await client.uploadDirectory(directory, filename);
   } catch (error) {
     console.log(error);
   }


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->

Please check the `const { skylink } = await client.upload(file, { skykeyName: "my-skykey" });` line aswell.