### PR TITLE
added documentation for getFileContent()

### DIFF
--- a/source/v3-beta/includes/_browser-js-api.md
+++ b/source/v3-beta/includes/_browser-js-api.md
@@ -40,7 +40,7 @@ const skylink = "AACJjVpOpsZ6c9PBwOYvxTtDc_nmrGxTTEomHDBEEfvRhA"; // JSON File
 let skyfile = {}
 
 try {
-  skyfile = await client.getFileContent(skylink);
+  const { data } = await client.getFileContent(skylink);
   console.log(skyfile.data.fruit) //prints 'Apple'
 } catch (error) {
   console.log(error);

--- a/source/v3-beta/includes/_browser-js-api.md
+++ b/source/v3-beta/includes/_browser-js-api.md
@@ -72,7 +72,7 @@ Field | Description
 
 Field | Description
 ------| -----------
-`data` | Data returned in the request body when doing a GET request for the skylink.
+`data` | Data returned in the response body when doing a GET request for the skylink.
 `skylink` | This is the skylink that can be used when downloading to retrieve the file that has been uploaded. It is a 46-character base64 encoded string that consists of the merkle root, offset, fetch size, and Skylink version which can be used to access the content.
 `contentType` | String representing the file's content type.
 `metadata` | Object returned in the `skynet-metadata` header when accessing the file 

--- a/source/v3-beta/includes/_browser-js-api.md
+++ b/source/v3-beta/includes/_browser-js-api.md
@@ -30,6 +30,57 @@ See [Downloading A File](#downloading-a-file).
 
 Empty on success.
 
+## Loading A File's Contents
+
+```javascript--browser
+import { SkynetClient } from "skynet-js";
+
+const client = new SkynetClient();
+const skylink = "AACJjVpOpsZ6c9PBwOYvxTtDc_nmrGxTTEomHDBEEfvRhA"; // JSON File
+let skyfile = {}
+
+try {
+  skyfile = await client.getFileContent(skylink);
+  console.log(skyfile.data.fruit) //prints 'Apple'
+} catch (error) {
+  console.log(error);
+}
+```
+
+Use the client to load a skylink's content for use by application.
+
+### Parameters
+
+Field | Description
+----- | -----------
+`skylink` | The skylink that should be downloaded. The skylink can contain an optional path.
+
+### Response
+
+```javascript--browser
+{
+  data: { fruit: 'Apple', size: 'Large', color: 'Red' },
+  contentType: 'application/json',
+  metadata: {
+    filename: 'example_1.json',
+    length: 65,
+    subfiles: { 'example_1.json': [Object] }
+  },
+  skylink: 'sia:AACJjVpOpsZ6c9PBwOYvxTtDc_nmrGxTTEomHDBEEfvRhA'
+}
+```
+
+Field | Description
+------| -----------
+`data` | Data returned in the request body when doing a GET request for the skylink.
+`skylink` | This is the skylink that can be used when downloading to retrieve the file that has been uploaded. It is a 46-character base64 encoded string that consists of the merkle root, offset, fetch size, and Skylink version which can be used to access the content.
+`contentType` | String representing the file's content type.
+`metadata` | Object returned in the `skynet-metadata` header when accessing the file 
+
+<aside class="warning">
+There are no checks in place for this method, and it is not advised to try and load the contents of excessively large files. You may want to run `getMetadata` first to check a file's size before running this method.
+</aside>
+
 ## Getting The Download URL
 
 ```javascript--browser
@@ -53,9 +104,9 @@ See [Downloading A File](#downloading-a-file).
 
 ### Additional Options
 
-Field | Description | Default
------ | ----------- | -------
-`download` | Option to include download directive in the url that will force a download when used. | `false`
+| Field      | Description                                                                           | Default |
+| ---------- | ------------------------------------------------------------------------------------- | ------- |
+| `download` | Option to include download directive in the url that will force a download when used. | `false` |
 
 ### Response
 
@@ -63,9 +114,9 @@ Field | Description | Default
 "https://siasky.net/XABvi7JtJbQSMAcDwnUnmp2FKDPjg8_tTTFP4BwMSxVdEg"
 ```
 
-Field | Description
-------| -----------
-`url` | The URL for the given skylink on the client portal.
+| Field | Description                                         |
+| ----- | --------------------------------------------------- |
+| `url` | The URL for the given skylink on the client portal. |
 
 ## Getting A Handshake URL
 
@@ -90,9 +141,9 @@ See [Downloading Handshake Files](#downloading-handshake-files).
 
 ### Additional Options
 
-Field | Description | Default
------ | ----------- | -------
-`download` | Option to include download directive in the url that will force a download when used. | `false`
+| Field      | Description                                                                           | Default |
+| ---------- | ------------------------------------------------------------------------------------- | ------- |
+| `download` | Option to include download directive in the url that will force a download when used. | `false` |
 
 ### Response
 
@@ -100,9 +151,9 @@ Field | Description | Default
 "https://siasky.net/hns/doesn"
 ```
 
-Field | Description
-------| -----------
-`url` | The URL for the given Handshake domain on the client portal.
+| Field | Description                                                  |
+| ----- | ------------------------------------------------------------ |
+| `url` | The URL for the given Handshake domain on the client portal. |
 
 ## Getting A Handshake Resolver URL
 
@@ -128,9 +179,9 @@ See [Resolving Handshake Domains](#resolving-handshake-domains).
 
 ### Additional Options
 
-Field | Description | Default
------ | ----------- | -------
-`download` | Option to include download directive in the url that will force a download when used. | `false`
+| Field      | Description                                                                           | Default |
+| ---------- | ------------------------------------------------------------------------------------- | ------- |
+| `download` | Option to include download directive in the url that will force a download when used. | `false` |
 
 ### Response
 
@@ -138,9 +189,9 @@ Field | Description | Default
 "https://siasky.net/hnsres/doesn"
 ```
 
-Field | Description
-------| -----------
-`url` | The URL for the given Handshake Resolver domain on the client portal.
+| Field | Description                                                           |
+| ----- | --------------------------------------------------------------------- |
+| `url` | The URL for the given Handshake Resolver domain on the client portal. |
 
 ## Parsing Skylinks
 
@@ -161,9 +212,9 @@ Extract a skylink from a string.
 
 ### Parameters
 
-Field | Description
------ | -----------
-`string` | The string to extract a skylink from.
+| Field    | Description                           |
+| -------- | ------------------------------------- |
+| `string` | The string to extract a skylink from. |
 
 Currently supported string types are:
 
@@ -178,6 +229,6 @@ Currently supported string types are:
 "CABAB_1Dt0FJsxqsu_J4TodNCbCGvtFf1Uys_3EgzOlTcg"
 ```
 
-Field | Description
-------| -----------
-`skylink` | See [Uploading A File](#uploading-a-file).
+| Field     | Description                                |
+| --------- | ------------------------------------------ |
+| `skylink` | See [Uploading A File](#uploading-a-file). |

--- a/source/v3-beta/includes/_browser-js-api.md
+++ b/source/v3-beta/includes/_browser-js-api.md
@@ -37,11 +37,10 @@ import { SkynetClient } from "skynet-js";
 
 const client = new SkynetClient();
 const skylink = "AACJjVpOpsZ6c9PBwOYvxTtDc_nmrGxTTEomHDBEEfvRhA"; // JSON File
-let skyfile = {}
 
 try {
   const { data } = await client.getFileContent(skylink);
-  console.log(skyfile.data.fruit) //prints 'Apple'
+  console.log(data.fruit) //prints 'Apple'
 } catch (error) {
   console.log(error);
 }
@@ -51,9 +50,9 @@ Use the client to load a skylink's content for use by application.
 
 ### Parameters
 
-Field | Description
------ | -----------
-`skylink` | The skylink that should be downloaded. The skylink can contain an optional path.
+| Field     | Description                                                                      |
+| --------- | -------------------------------------------------------------------------------- |
+| `skylink` | The skylink that should be downloaded. The skylink can contain an optional path. |
 
 ### Response
 
@@ -70,12 +69,12 @@ Field | Description
 }
 ```
 
-Field | Description
-------| -----------
-`data` | Data returned in the response body when doing a GET request for the skylink.
-`skylink` | This is the skylink that can be used when downloading to retrieve the file that has been uploaded. It is a 46-character base64 encoded string that consists of the merkle root, offset, fetch size, and Skylink version which can be used to access the content.
-`contentType` | String representing the file's content type.
-`metadata` | Object returned in the `skynet-metadata` header when accessing the file 
+| Field         | Description                                                                                                                                                                                                                                                      |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `data`        | Data returned in the response body when doing a GET request for the skylink.                                                                                                                                                                                     |
+| `skylink`     | This is the skylink that can be used when downloading to retrieve the file that has been uploaded. It is a 46-character base64 encoded string that consists of the merkle root, offset, fetch size, and Skylink version which can be used to access the content. |
+| `contentType` | String representing the file's content type.                                                                                                                                                                                                                     |
+| `metadata`    | Object returned in the `skynet-metadata` header when accessing the file                                                                                                                                                                                          |
 
 <aside class="warning">
 There are no checks in place for this method, and it is not advised to try and load the contents of excessively large files. You may want to run `getMetadata` first to check a file's size before running this method.


### PR DESCRIPTION
First commit to the Slate docs, adding documentation for `getFileContent()` since it could be important for some upcoming partnerships.

First PR for the Slate docs, so review carefully :)